### PR TITLE
Add PriorityQueue.Queue.size_map(queue) function

### DIFF
--- a/lib/priority_key_server.ex
+++ b/lib/priority_key_server.ex
@@ -40,6 +40,14 @@ defmodule ProducerQueue.PriorityKeyServer do
   def init(opts), do: init(:priority, Keyword.get(opts, :priority, [:default]))
   def init(:priority, prio), do: {:ok, {prio, Enum.into(prio, %{}, &{&1, @q})}}
 
+  def handle_call(:size_map, _, {prio, queues} = state) do
+    for key <- prio, into: %{} do
+      {key, queues |> Map.get(key) |> elem(0)}
+    end
+    |> Map.put(:_, prio)
+    |> then(&{:reply, &1, state})
+  end
+
   def handle_call({:pop, count}, _, state), do: out(count, state)
   def handle_call({:push, list}, _, state), do: {:reply, :ok, qin(list, state)}
   def handle_cast({:push, list}, state), do: {:noreply, qin(list, state)}

--- a/lib/queue.ex
+++ b/lib/queue.ex
@@ -40,6 +40,11 @@ defmodule ProducerQueue.Queue do
   end
 
   @doc ~s"""
+  Get queue size
+  """
+  def size_map(queue), do: GenServer.call(queue, :size_map, @wait)
+
+  @doc ~s"""
   Pop a number of items of the front of a queue (timeout: #{@wait})
 
   ## Example


### PR DESCRIPTION
This sends a message to the process holding the complex `:queue` tuple.

We're already storing the size of each queue in the complex queue, so this just fetches the size (elem(0) in each queue).

Calling `:queue.len()` on the queues give the same results, is much slower on large queues because it needs to traverse the lists.

## Usage:

```elixir
    iex> ProducerQueue.Queue.size_map(Ocs.NetworkDevice.UsageUpdateQueue)
    %{_: [:default], default: 0}
```