### PR TITLE
[FLI-6705] Add hex package metadata for private Hex repo publishing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Flickswitch
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -2,18 +2,21 @@
 
 ## Installation
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `producer_queue` to your list of dependencies in `mix.exs`:
+Published to the private `flickswitch` Hex repo. Add the repo once per machine
+(reads are open, no auth token needed):
+
+```sh
+curl -sS https://hex.flickswitch.cloud/repos/flickswitch/public_key -o /tmp/flickswitch_hex_public_key.pem
+mix hex.repo add flickswitch https://hex.flickswitch.cloud/repos/flickswitch --public-key /tmp/flickswitch_hex_public_key.pem
+```
+
+then in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:producer_queue, "~> 5.0"}
+    {:producer_queue, "~> 5.0", repo: "flickswitch"}
   ]
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/producer_queue](https://hexdocs.pm/producer_queue).
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,17 @@ defmodule ProducerQueue.MixProject do
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      test_coverage: [tool: ExCoveralls]
+      test_coverage: [tool: ExCoveralls],
+      description: "Elixir library for basic prioritized queues with a producer for Broadway",
+      package: package()
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["MIT"],
+      links: %{"GitHub" => "https://github.com/Flickswitch/producer_queue"},
+      files: ~w(lib mix.exs README.md LICENSE)
     ]
   end
 


### PR DESCRIPTION
Closes FLI-6705 (producer_queue portion). Mirrors Flickswitch/searchable-select#40.

## What

- `mix.exs`: add `description` and a `package/0` block — MIT license, GitHub link, explicit file list (`lib mix.exs README.md LICENSE`).
- `LICENSE`: add the MIT license text. The repo had no license file at all, so `licenses: ["MIT"]` had nothing behind it.
- `README.md`: replace the stale "if available in Hex" hex.pm boilerplate with the private `flickswitch` repo setup — the one-time `mix hex.repo add` and the `repo: "flickswitch"` dep line.

## Why

We now self-host a private Hex repository at `hex.flickswitch.cloud` so internal packages are consumed as versioned hex deps instead of raw GitHub git deps. `producer_queue` 5.0.3 was seeded there by hand; this makes future releases publishable the normal way.

## Notes for reviewers

- **License**: the repo carried no license, and GitHub reported none. MIT, copyright Flickswitch, 2026.
- `example/` and `test/` are deliberately excluded from `files`.
- `mix hex.build` is clean — no missing-metadata warnings, and all three `lib/` files ship (`producer.ex`, `queue.ex`, `priority_key_server.ex`).
- Public key is served at `/repos/flickswitch/public_key` (verified 200), **not** `/public_key` as written on the Linear issue.
- Publishing a release still needs an API token from SRE and a version bump (5.0.3 is already on the registry and hex won't overwrite it). A CI publish step is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
